### PR TITLE
Mention flag is required on Linux only

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ At the time of writing, only Chrome, Edge and Opera browsers have
 support for these APIs.
 
 Currently all testing is done with Chrome on Windows 10.
-You may need to first set this flag to enable the Bluetooth API:
-`chrome://flags/#enable-experimental-web-platform-features`.
+If you're on Linux, you may need to first set this flag to enable the Web
+Bluetooth API: `chrome://flags/#enable-experimental-web-platform-features`.
 
 Please open a [ticket](https://github.com/GameWithPixels/PixelsWebPackage/issues)
 in GitHub if you're having any issue.


### PR DESCRIPTION
The experimental flag `chrome://flags/#enable-experimental-web-platform-features` is dangerous as it will enable plenty of experimental web platform features,  not just Web Bluetooth.

We should be careful and specify that this is required only for Linux as it is still experimental on this platform.

Note: I can't wait to try this out ;)